### PR TITLE
removed jenkins and jnlp service env vars from ex.

### DIFF
--- a/config/samples/openshift_jenkins_v1alpha2_jenkins_cr.yaml
+++ b/config/samples/openshift_jenkins_v1alpha2_jenkins_cr.yaml
@@ -28,10 +28,6 @@ spec:
         value: 'https://kubernetes.default:443'
       - name: KUBERNETES_TRUST_CERTIFICATES
         value: 'true'
-      - name: JENKINS_SERVICE_NAME
-        value: jenkins-jenkins
-      - name: JNLP_SERVICE_NAME
-        value: jenkins-jenkins-jnlp
       - name: JENKINS_UC_INSECURE
         value: 'false'
       - name: JENKINS_HOME


### PR DESCRIPTION
Removed from the OpenShift sample Jenkins CR:
      - name: JENKINS_SERVICE_NAME
        value: jenkins-jenkins
      - name: JNLP_SERVICE_NAME
        value: jenkins-jenkins-jnlp