### PR TITLE
Restore /manager as entrypoint to unlock smoke tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ COPY pkg/ pkg/
 COPY version/ version/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o jenkins-operator main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/jenkins-operator .
+COPY --from=builder /workspace/manager .
 USER nonroot:nonroot
 
-ENTRYPOINT ["/jenkins-operator"]
+ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ operator: goimports fmt vet generate test bin ## Builds operator binary
 
 bin: # Builds operator binary only 
 	@echo "${BLUE}Building ${OPERATOR_NAME} ${YELLOW}binary${BLUE}${RESET}"
-	@go build -o build/_output/bin/jenkins-operator main.go
+	@go build -o build/_output/bin/manager main.go
 
 ## Bundle and image related targets
 operator-image: operator## Build the operator container image

--- a/openshift-ci/Dockerfile.build_image
+++ b/openshift-ci/Dockerfile.build_image
@@ -59,6 +59,6 @@ LABEL maintainer "openshift-dev-services+jenkins@redhat.com"
 ENV LANG=en_US.utf8
 ENV GOPATH=/tmp/go
 
-COPY --from=builder /tmp/go/src/github.com/jenkinsci/jenkins-automation-operator/build/_output/bin/jenkins-operator /jenkins-operator
-ENTRYPOINT [ "/jenkins-operator" ]
+COPY --from=builder /tmp/go/src/github.com/jenkinsci/jenkins-automation-operator/build/_output/bin/manager /manager
+ENTRYPOINT [ "/manager" ]
 


### PR DESCRIPTION
Restore /manager as entrypoint to unlock smoke tests