### PR TITLE
JKNS-243: OpenShift Platform Support

### DIFF
--- a/redhat-release/jenkins-operator-bundle/Dockerfile
+++ b/redhat-release/jenkins-operator-bundle/Dockerfile
@@ -3,7 +3,7 @@ COPY ./bundle/manifests /manifests
 COPY ./bundle/metadata/annotations.yaml /metadata/annotations.yaml
 
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.6,v4.7,v4.8"
+LABEL com.redhat.openshift.versions="v4.6-v4.9"
 LABEL com.redhat.delivery.backport=false
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -22,4 +22,3 @@ LABEL io.k8s.display-name="Jenkins Operator bundle"
 LABEL description="Jenkins Operator bundle for Jenkins Operator"
 
 LABEL A=B
-


### PR DESCRIPTION
Adjusting label `com.redhat.openshift.versions` to support OpenShift Platform from v4.6 until v4.9 ([`v4.6-v4.9`](https://docs.engineering.redhat.com/display/CFC/Delivery)).